### PR TITLE
Made backtraces optional.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,5 +18,9 @@ description = "A `dotenv` implementation for Rust"
 
 [dependencies]
 derive-error-chain = "0.10.0"
-error-chain = "0.10.0"
+error-chain = { version = "0.10.0", default-features = false }
 regex = "0.2.1"
+
+[features]
+backtrace = ["error-chain/backtrace"]
+default = ["backtrace"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@ use std::sync::{Once, ONCE_INIT};
 use regex::{Captures, Regex};
 
 #[derive(Debug, error_chain)]
+#[cfg_attr(not(feature = "backtrace"), error_chain(backtrace = "false"))]
 pub enum ErrorKind {
     // generic error string, required by derive_error_chain
     Msg(String),


### PR DESCRIPTION
At the moment the `dotenv` crate forces the feature `backtrace` of `error-chain` on. This PR makes it optional, allowing users to opt out from backtrace-including errors when they are using `dotenv`.

The backtraces are still, as of the default, on, like they used to be.