### PR TITLE
bump error-chain to 0.11.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ repository = "https://github.com/purpliminal/rust-dotenv"
 description = "A `dotenv` implementation for Rust"
 
 [dependencies]
-derive-error-chain = "0.10.0"
-error-chain = { version = "0.10.0", default-features = false }
+derive-error-chain = "0.11.0"
+error-chain = { version = "0.11.0", default-features = false }
 regex = "0.2.1"
 
 [features]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ use std::path::{Path, PathBuf};
 use std::sync::{Once, ONCE_INIT};
 use regex::{Captures, Regex};
 
-#[derive(Debug, error_chain)]
+#[derive(Debug, ErrorChain)]
 #[cfg_attr(not(feature = "backtrace"), error_chain(backtrace = "false"))]
 pub enum ErrorKind {
     // generic error string, required by derive_error_chain


### PR DESCRIPTION
`derive-error-chain`: proc macro `error_chain` has been renamed to `ErrorChain`.