### PR TITLE
Avoid testing `/tests` from outside its folder on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,6 @@ language: rust
 sudo: false
 script:
   - cargo build --verbose
-  - cargo test --verbose
+  - cargo test --verbose --lib --doc
   - cd tests
   - cargo test --verbose


### PR DESCRIPTION
This PR contains a quick fix to stop Travis builds from failing.

It seems that, starting on cargo 0.23, running `cargo test` will execute the tests on the `tests` folder. This is unfortunate, since our tests expect to be ran from the `tests` folder. This fixes the issue on Travis, by only running library and documentation tests when outside the `tests` folder.

A separate issue will be opened to address the fact that `cargo test` fails when ran unqualified on the root folder of the project, which is definitely concerning.