### PR TITLE
Use AsRef<Path> generic type parameter instead of &str or &Path

### DIFF
--- a/src/find.rs
+++ b/src/find.rs
@@ -53,7 +53,7 @@ pub fn find<P: AsRef<Path>>(directory: P, filename: &Path) -> Result<PathBuf> {
     }
 
     if let Some(parent) = directory.as_ref().parent() {
-        find(parent, filename.as_ref())
+        find(parent, filename)
     } else {
         Err(io::Error::new(io::ErrorKind::NotFound, "path not found").into())
     }

--- a/src/find.rs
+++ b/src/find.rs
@@ -5,21 +5,21 @@ use std::{env, fs, io};
 use errors::*;
 use iter::Iter;
 
-pub struct Finder {
+pub struct Finder<'a> {
   directory: Option<PathBuf>,
-  filename:  PathBuf,
+  filename:  &'a Path,
 }
 
-impl Finder {
+impl<'a> Finder<'a> {
     pub fn new() -> Self {
         Finder {
             directory: None,
-            filename: ".env".into(),
+            filename: Path::new(".env"),
         }
     }
 
-    pub fn filename<P: AsRef<Path>>(mut self, filename: P) -> Self {
-        self.filename = filename.as_ref().into();
+    pub fn filename(mut self, filename: &'a Path) -> Self {
+        self.filename = filename;
         self
     }
 
@@ -38,8 +38,8 @@ impl Finder {
 }
 
 /// Searches for `filename` in `directory` and parent directories until found or root is reached.
-pub fn find<P: AsRef<Path>>(directory: P, filename: P) -> Result<PathBuf> {
-    let candidate = directory.as_ref().join(filename.as_ref());
+pub fn find<P: AsRef<Path>>(directory: P, filename: &Path) -> Result<PathBuf> {
+    let candidate = directory.as_ref().join(filename);
 
     match fs::metadata(&candidate) {
         Ok(metadata) => if metadata.is_file() {

--- a/src/find.rs
+++ b/src/find.rs
@@ -30,7 +30,7 @@ impl<'a> Finder<'a> {
             env::current_dir()?
         };
 
-        let path = find(directory, self.filename)?;
+        let path = find(&directory, self.filename)?;
         let file = File::open(&path)?;
         let iter = Iter::new(file);
         Ok((path, iter))
@@ -38,8 +38,8 @@ impl<'a> Finder<'a> {
 }
 
 /// Searches for `filename` in `directory` and parent directories until found or root is reached.
-pub fn find<P: AsRef<Path>>(directory: P, filename: &Path) -> Result<PathBuf> {
-    let candidate = directory.as_ref().join(filename);
+pub fn find(directory: &Path, filename: &Path) -> Result<PathBuf> {
+    let candidate = directory.join(filename);
 
     match fs::metadata(&candidate) {
         Ok(metadata) => if metadata.is_file() {
@@ -52,7 +52,7 @@ pub fn find<P: AsRef<Path>>(directory: P, filename: &Path) -> Result<PathBuf> {
         }
     }
 
-    if let Some(parent) = directory.as_ref().parent() {
+    if let Some(parent) = directory.parent() {
         find(parent, filename)
     } else {
         Err(io::Error::new(io::ErrorKind::NotFound, "path not found").into())

--- a/src/find.rs
+++ b/src/find.rs
@@ -11,30 +11,30 @@ pub struct Finder {
 }
 
 impl Finder {
-  pub fn new() -> Self {
-    Finder {
-      directory: None,
-      filename:  ".env".into(),
+    pub fn new() -> Self {
+        Finder {
+            directory: None,
+            filename: ".env".into(),
+        }
     }
-  }
 
-  pub fn filename<P: AsRef<Path>>(mut self, filename: P) -> Self {
-    self.filename = filename.as_ref().into();
-    self
-  }
+    pub fn filename<P: AsRef<Path>>(mut self, filename: P) -> Self {
+        self.filename = filename.as_ref().into();
+        self
+    }
 
-  pub fn find(self) -> Result<(PathBuf, Iter<File>)> {
-    let directory = if let Some(directory) = self.directory {
-      directory
-    } else {
-      env::current_dir()?
-    };
+    pub fn find(self) -> Result<(PathBuf, Iter<File>)> {
+        let directory = if let Some(directory) = self.directory {
+            directory
+        } else {
+            env::current_dir()?
+        };
 
-    let path = find(directory, self.filename)?;
-    let file = File::open(&path)?;
-    let iter = Iter::new(file);
-    Ok((path, iter))
-  }
+        let path = find(directory, self.filename)?;
+        let file = File::open(&path)?;
+        let iter = Iter::new(file);
+        Ok((path, iter))
+    }
 }
 
 /// Searches for `filename` in `directory` and parent directories until found or root is reached.

--- a/src/find.rs
+++ b/src/find.rs
@@ -18,7 +18,7 @@ impl Finder {
     }
   }
 
-  pub fn filename<P: AsRef<Path>>(mut self, filename: P) -> Finder {
+  pub fn filename<P: AsRef<Path>>(mut self, filename: P) -> Self {
     self.filename = filename.as_ref().into();
     self
   }

--- a/src/find.rs
+++ b/src/find.rs
@@ -6,14 +6,12 @@ use errors::*;
 use iter::Iter;
 
 pub struct Finder<'a> {
-  directory: Option<PathBuf>,
   filename:  &'a Path,
 }
 
 impl<'a> Finder<'a> {
     pub fn new() -> Self {
         Finder {
-            directory: None,
             filename: Path::new(".env"),
         }
     }
@@ -24,13 +22,7 @@ impl<'a> Finder<'a> {
     }
 
     pub fn find(self) -> Result<(PathBuf, Iter<File>)> {
-        let directory = if let Some(directory) = self.directory {
-            directory
-        } else {
-            env::current_dir()?
-        };
-
-        let path = find(&directory, self.filename)?;
+        let path = find(&env::current_dir()?, self.filename)?;
         let file = File::open(&path)?;
         let iter = Iter::new(file);
         Ok((path, iter))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,7 +125,7 @@ pub fn from_path_iter<P: AsRef<Path>>(path: P) -> Result<Iter<File>> {
 /// dotenv::from_filename(".env").ok();
 /// ```
 pub fn from_filename<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
-    let (path, iter) = Finder::new().filename(filename).find()?;
+    let (path, iter) = Finder::new().filename(filename.as_ref()).find()?;
     iter.load()?;
     Ok(path)
 }
@@ -151,7 +151,7 @@ pub fn from_filename<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
 /// }
 /// ```
 pub fn from_filename_iter<P: AsRef<Path>>(filename: P) -> Result<Iter<File>> {
-    let (_, iter) = Finder::new().filename(filename).find()?;
+    let (_, iter) = Finder::new().filename(filename.as_ref()).find()?;
     Ok(iter)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,7 +84,7 @@ pub fn vars() -> Vars {
 /// let my_path = env::home_dir().and_then(|a| Some(a.join("/.env"))).unwrap();
 /// dotenv::from_path(my_path.as_path());
 /// ```
-pub fn from_path(path: &Path) -> Result<()> {
+pub fn from_path<P: AsRef<Path>>(path: P) -> Result<()> {
     from_path_iter(path)?.load()
 }
 
@@ -105,7 +105,7 @@ pub fn from_path(path: &Path) -> Result<()> {
 ///   println!("{}={}", key, val);
 /// }
 /// ```
-pub fn from_path_iter(path: &Path) -> Result<Iter<File>> {
+pub fn from_path_iter<P: AsRef<Path>>(path: P) -> Result<Iter<File>> {
     Ok(Iter::new(File::open(path)?))
 }
 
@@ -124,7 +124,7 @@ pub fn from_path_iter(path: &Path) -> Result<Iter<File>> {
 /// use dotenv;
 /// dotenv::from_filename(".env").ok();
 /// ```
-pub fn from_filename(filename: &str) -> Result<PathBuf> {
+pub fn from_filename<P: AsRef<Path>>(filename: P) -> Result<PathBuf> {
     let (path, iter) = Finder::new().filename(filename).find()?;
     iter.load()?;
     Ok(path)
@@ -150,7 +150,7 @@ pub fn from_filename(filename: &str) -> Result<PathBuf> {
 ///   println!("{}={}", key, val);
 /// }
 /// ```
-pub fn from_filename_iter(filename: &str) -> Result<Iter<File>> {
+pub fn from_filename_iter<P: AsRef<Path>>(filename: P) -> Result<Iter<File>> {
     let (_, iter) = Finder::new().filename(filename).find()?;
     Ok(iter)
 }


### PR DESCRIPTION
For filename operations, it might be better to accept anything that is `AsRef<Path>` instead of limiting input to only `&str`or `&Path`.

As a bonus `directory` argument of `find()` function is not `mut` anymore.