### PR TITLE
Lazily initialize line regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ description = "A `dotenv` implementation for Rust"
 [dependencies]
 derive-error-chain = "0.11.0"
 error-chain = { version = "0.11.0", default-features = false }
+lazy_static = "1.0.0"
 regex = "0.2.1"
 
 [dev-dependencies]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -10,8 +10,6 @@ pub enum ErrorKind {
     #[error_chain(display = r#"|l| write!(f, "Error parsing line: '{}'", l)"#)]
     LineParse(String),
     #[error_chain(foreign)]
-    ParseFormatter(::regex::Error),
-    #[error_chain(foreign)]
     Io(::std::io::Error),
     #[error_chain(foreign)]
     EnvVar(::std::env::VarError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@
 extern crate derive_error_chain;
 #[macro_use]
 extern crate error_chain;
+#[macro_use]
+extern crate lazy_static;
 extern crate regex;
 
 mod parse;

--- a/src/parse.rs
+++ b/src/parse.rs
@@ -5,7 +5,8 @@ use errors::*;
 pub type ParsedLine = Result<Option<(String, String)>>;
 
 pub fn parse_line(line: String) -> ParsedLine {
-    let line_regex = try!(Regex::new(concat!(
+    lazy_static! {
+      static ref LINE_REGEX: Regex = Regex::new(concat!(
         r"^(\s*(",
         r"#.*|",                            // A comment, or...
         r"\s*|",                            // ...an empty string, or...
@@ -14,9 +15,10 @@ pub fn parse_line(line: String) -> ParsedLine {
         r"=",                               // ...then an equal sign,...
         r"(?P<value>.+?)?",                 // ...and then its corresponding value.
         r")\s*)[\r\n]*$"
-    )));
+      )).unwrap();
+    }
 
-    line_regex
+    LINE_REGEX
         .captures(&line)
         .map_or(Err(ErrorKind::LineParse(line.clone()).into()), |captures| {
             let key = named_string(&captures, "key");


### PR DESCRIPTION
Moves the line regex into a lazy static, so we only initialize it once per run. Also, since the regex should always compile, unwrap it and remove the corresponding enum error variant.