### PR TITLE
Update dotenv syn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ sudo: false
 script:
   - cargo build --verbose
   - cargo test --verbose
+  - (cd dotenv_codegen; cargo build --verbose)
+  - (cd dotenv_codegen; cargo test --verbose)

--- a/dotenv_codegen/.env
+++ b/dotenv_codegen/.env
@@ -1,0 +1,2 @@
+CODEGEN_TEST_VAR1="hello!"
+CODEGEN_TEST_VAR2="'quotes within quotes'"

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -19,6 +19,5 @@ description = "A `dotenv` implementation for Rust"
 [workspace]
 
 [dependencies]
-dotenv = "0.11.0"
 dotenv_codegen_impl = { version = "0.1", path = "dotenv_codegen_impl" }
 proc-macro-hack = "0.4"

--- a/dotenv_codegen/Cargo.toml
+++ b/dotenv_codegen/Cargo.toml
@@ -19,6 +19,6 @@ description = "A `dotenv` implementation for Rust"
 [workspace]
 
 [dependencies]
-dotenv = "^0.8.0"
-proc-macro-hack = "0.4"
+dotenv = "0.11.0"
 dotenv_codegen_impl = { version = "0.1", path = "dotenv_codegen_impl" }
+proc-macro-hack = "0.4"

--- a/dotenv_codegen/dotenv_codegen_impl/Cargo.toml
+++ b/dotenv_codegen/dotenv_codegen_impl/Cargo.toml
@@ -21,5 +21,6 @@ proc-macro = true
 [dependencies]
 dotenv = "0.11.0"
 proc-macro-hack = "0.4"
-quote = "0.3"
-syn = "0.11"
+proc-macro2 = "0.2"
+quote = "0.4"
+syn = "0.12"

--- a/dotenv_codegen/dotenv_codegen_impl/Cargo.toml
+++ b/dotenv_codegen/dotenv_codegen_impl/Cargo.toml
@@ -19,7 +19,7 @@ description = "A `dotenv` implementation for Rust"
 proc-macro = true
 
 [dependencies]
-dotenv = "^0.8.0"
+dotenv = "0.11.0"
 proc-macro-hack = "0.4"
 quote = "0.3"
 syn = "0.11"

--- a/dotenv_codegen/dotenv_codegen_impl/src/lib.rs
+++ b/dotenv_codegen/dotenv_codegen_impl/src/lib.rs
@@ -42,9 +42,7 @@ fn expand_env(input_raw: &str) -> String {
     let buf = TokenBuffer::new2(stream);
 
     let args: Punctuated<syn::LitStr, Token![,]> = Punctuated::parse_terminated(buf.begin())
-        .expect(
-            "expected macro to be called with a comma-separated list of string literals",
-        )
+        .expect("expected macro to be called with a comma-separated list of string literals")
         .0;
 
     let mut iter = args.iter();

--- a/dotenv_codegen/dotenv_codegen_impl/src/lib.rs
+++ b/dotenv_codegen/dotenv_codegen_impl/src/lib.rs
@@ -9,14 +9,15 @@ extern crate syn;
 
 use std::env;
 
-use dotenv::DotenvError::Parsing;
 use dotenv::dotenv;
 use syn::{TokenTree, Token, Lit};
 
 proc_macro_expr_impl! {
     pub fn expand_dotenv(input: &str) -> String {
-        if let Err(Parsing { line }) = dotenv() {
-            panic!("Error parsing .env file: {}", line);
+        if let Err(err) = dotenv() {
+            if let &dotenv::ErrorKind::LineParse(ref line) = err.kind() {
+                panic!("Error parsing .env file: {}", line);
+            }
         }
 
         // Either everything was fine, or we didn't find an .env file (which we ignore)

--- a/dotenv_codegen/dotenv_codegen_impl/src/lib.rs
+++ b/dotenv_codegen/dotenv_codegen_impl/src/lib.rs
@@ -23,6 +23,8 @@ proc_macro_expr_impl! {
         if let Err(err) = dotenv() {
             if let &dotenv::ErrorKind::LineParse(ref line) = err.kind() {
                 panic!("Error parsing .env file: {}", line);
+            } else {
+                panic!("Error loading .env file: {}", err);
             }
         }
 

--- a/dotenv_codegen/tests/basic_dotenv_macro.rs
+++ b/dotenv_codegen/tests/basic_dotenv_macro.rs
@@ -1,0 +1,19 @@
+#[macro_use]
+extern crate dotenv_codegen;
+
+#[test]
+fn dotenv_works() {
+    assert_eq!(dotenv!("CODEGEN_TEST_VAR1"), "hello!");
+}
+
+#[test]
+fn two_argument_form_works() {
+    assert_eq!(
+        dotenv!(
+            "CODEGEN_TEST_VAR2",
+            "err, you should be running this in the 'dotenv_codegen' \
+             directory to pick up the right .env file."
+        ),
+        "'quotes within quotes'"
+    );
+}


### PR DESCRIPTION
This updates the 'syn' dependency of dotenv_codegen. Depends on #88.

Fixes #90.