### PR TITLE
Add a note regarding CLI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,3 +83,15 @@ fn main() {
 ```
 
 [dotenv]: https://github.com/bkeepers/dotenv
+
+
+Using CLI command
+-----------------
+
+You can also use `dotenv` as a CLI command that reads environment variables from `.env` file.
+
+For that you need to install `dotenv` with the following command
+
+```
+cargo install dotenv --bin dotenv --features=cli
+```


### PR DESCRIPTION
Thanks for the nice tool.

I added a little note to README about how to install CLI command.

It's probably enough to close this issue: https://github.com/purpliminal/rust-dotenv/issues/104