### PR TITLE
Clarify dotenv macro usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ use the `from_filename` and `from_path` methods provided by the crate.
 
 `dotenv_codegen` provides the `dotenv!` macro, which
 behaves identically to `env!`, but first tries to load a `.env` file at compile
-time.
+time. This macro does autoloads the `.env` file and cannot be configured to use
+another config file.
 
 Examples
 ----
@@ -66,8 +67,8 @@ fn main() {
 Using the `dotenv!` macro
 ------------------------------------
 
-Add `dotenv_codegen` to your dependencies, and add the following to the top of
-your crate:
+Add `dotenv_codegen` to your dependencies, ensure to have an `.env` file
+and add the following to the top of your crate:
 
 ```rust
 #[macro_use]

--- a/dotenv_codegen/src/lib.rs
+++ b/dotenv_codegen/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate provides usage of the `dotenv` crate as a macro.
+//! This macro can only work with a .env file, loading an alternate
+//! configuration file is not available.
+
 #[macro_use]
 extern crate proc_macro_hack;
 


### PR DESCRIPTION
Hello,

this is probably a useless contribution, but.

It took me a bit of time (and checking the code of the `dotenv!()`) before realizing that it only works autoloading the `.env` file and that one cannot customize the config file (as it is the case for the plain `dotenv::from_filename()` usage).

I'm not sure this little clarification is actually useful to anyone but me :-) it would make sense to simply  drop it in the dustbin.

opinions?

thanks for having a look at this.